### PR TITLE
Remove the Progress Bar After Loading.

### DIFF
--- a/modules/main.ts
+++ b/modules/main.ts
@@ -48,7 +48,7 @@ export class Main {
         win.on("ready-to-show", () => {
           win.maximize();
           win.show();
-          win.setProgressBar(0);
+          win.setProgressBar(-1);
         });
 
         //win.webContents.openDevTools()


### PR DESCRIPTION
Setting setProgressBar to 0 won’t remove the progress bar. To remove it, the value should be -1