### PR TITLE
Progress Bar Remove After Download

### DIFF
--- a/modules/controllers/window-controller.ts
+++ b/modules/controllers/window-controller.ts
@@ -28,7 +28,7 @@ export class WindowController {
 
   // Set the progress bar to the given percentage. It will be shown in task bar
   public setProgress(progress: number) {
-    this.win?.setProgressBar(progress);
+      this.win?.setProgressBar(progress != 0 ? progress : -1);
   }
 
   unmaximize() {


### PR DESCRIPTION
After downloading an episode, the progress bar is not automatically removed. To resolve this, the status is set to -1 upon download completion, ensuring the progress bar is removed